### PR TITLE
Create the function to create a simple JSDOC conversion

### DIFF
--- a/pages/jsdoc.vue
+++ b/pages/jsdoc.vue
@@ -26,7 +26,20 @@ const clearInput = () => {
 };
 
 const generateJSDoc = () => {
-  jsdocOutput.value = 'WIP';
+  try {
+    const obj = JSON.parse(objectInput.value);
+    let jsdoc = `/**\n * @typedef {Object} GeneratedType\n`;
+
+    for (const [key, value] of Object.entries(obj)) {
+      const type = typeof value;
+      jsdoc += ` * @property {${type}} ${key}\n`;
+    }
+
+    jsdoc += ` */`;
+    jsdocOutput.value = jsdoc;
+  } catch (e) {
+    jsdocOutput.value = 'Invalid JSON input';
+  }
 };
 
 watch(objectInput, generateJSDoc);


### PR DESCRIPTION
Related to #7

Update `generateJSDoc` function to generate a JSDoc header with first-level properties of the object.

* Parse the `objectInput` and generate the JSDoc string.
* Update the `jsdocOutput` to display the generated JSDoc string.
* Add error handling for invalid JSON input.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Viserion77/supertool.digital/pull/10?shareId=06bd28d4-53fc-4ba4-86bd-2d0fb12e7654).