### PR TITLE
Enhance JSDoc generator to recognize arrays and be recursive

### DIFF
--- a/pages/jsdoc.vue
+++ b/pages/jsdoc.vue
@@ -60,10 +60,23 @@ const generateJSDoc = () => {
     const obj = JSON.parse(objectInput.value);
     let jsdoc = `/**\n * @typedef {Object} GeneratedType\n`;
 
-    for (const [key, value] of Object.entries(obj)) {
-      const type = typeof value;
-      jsdoc += ` * @property {${type}} ${key}\n`;
-    }
+    const processObject = (obj: Record<string, any>, prefix = "") => {
+      for (const [key, value] of Object.entries(obj)) {
+        let type: string = typeof value;
+        if (Array.isArray(value)) {
+          type = "Array";
+          if (value.length > 0) {
+            type += `<${typeof value[0]}>`;
+          }
+        } else if (type === "object" && value !== null) {
+          type = "Object";
+          processObject(value, `${prefix}${key}.`);
+        }
+        jsdoc += ` * @property {${type}} ${prefix}${key}\n`;
+      }
+    };
+
+    processObject(obj);
 
     jsdoc += ` */`;
     jsdocOutput.value = jsdoc;


### PR DESCRIPTION
Related to #17

Update `generateJSDoc` function in `pages/jsdoc.vue` to recognize arrays and be recursive.

* Add a `processObject` function to handle nested objects and arrays.
* Update `generateJSDoc` to call `processObject` for processing the input object.
* Recognize arrays and include their type in the JSDoc.
* Make the function recursive to process nested objects and arrays.

### Teste
```json
{
"a": 123,
"b": [],
"c": [],
"d": {"e": 1},
"f": [{"g": 1}],
"h": {"i": [1]},
"j": {"k": {"l": {"m": [1]}}}
}
```
Output:
```js
/**
 * @typedef {Object} GeneratedType
 * @property {number} a
 * @property {Array} b
 * @property {Array} c
 * @property {number} d.e
 * @property {Object} d
 * @property {Array<object>} f
 * @property {Array<number>} h.i
 * @property {Object} h
 * @property {Array<number>} j.k.l.m
 * @property {Object} j.k.l
 * @property {Object} j.k
 * @property {Object} j
 */
```

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Viserion77/supertool.digital/pull/18?shareId=4675740d-b792-4c56-bf2c-2e2bf6859a94).