### PR TITLE
Enhance generateJSDoc function to validate array child types and define new types for objects with more than 3 keys

### DIFF
--- a/pages/jsdoc.vue
+++ b/pages/jsdoc.vue
@@ -65,12 +65,30 @@ const generateJSDoc = () => {
         let type: string = typeof value;
         if (Array.isArray(value)) {
           type = "Array";
-          if (value.length > 0) {
+          if (value.length === 1) {
             type += `<${typeof value[0]}>`;
           }
+          if (value.length > 1) {
+            type += `<`;
+            const types = new Set<string>();
+            for (let i = 0; i < value.length; i++) {
+              types.add(typeof value[i]);
+            }
+            type += Array.from(types).join(" | ");
+            type += ">";
+          }
         } else if (type === "object" && value !== null) {
-          type = "Object";
-          processObject(value, `${prefix}${key}.`);
+          if (Object.keys(value).length > 3) {
+            const typeName = `${prefix}${key.charAt(0).toUpperCase() + key.slice(1)}Type`;
+            const bkp = jsdoc;
+            jsdoc = `/**\n * @typedef {Object} ${typeName}\n`;
+            processObject(value, "");
+            jsdoc += ` */\n${bkp}`;
+
+            type = typeName;
+          } else {
+            processObject(value, `${prefix}${key}.`);
+          }
         }
         jsdoc += ` * @property {${type}} ${prefix}${key}\n`;
       }


### PR DESCRIPTION
Related to #17

Update `generateJSDoc` function in `pages/jsdoc.vue` to handle arrays and objects more comprehensively.

* **Arrays**:
  - Add validation for each child type in arrays.
  - Handle arrays with multiple types by creating a union type.

* **Objects**:
  - Define new types for objects with more than 3 keys.
  - Process objects recursively and update JSDoc accordingly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Viserion77/supertool.digital/pull/19?shareId=c77482ad-6b73-41eb-9f33-efb73d4544a9).